### PR TITLE
Update Endjin.RecommendedPractices to 1.2.0

### DIFF
--- a/Solutions/Marain.Services.Tenancy.Testing/Marain.Services.Tenancy.Testing.csproj
+++ b/Solutions/Marain.Services.Tenancy.Testing/Marain.Services.Tenancy.Testing.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Services.Tenancy/Marain.Services.Tenancy.csproj
+++ b/Solutions/Marain.Services.Tenancy/Marain.Services.Tenancy.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.TenantManagement.Abstractions/Marain.TenantManagement.Abstractions.csproj
+++ b/Solutions/Marain.TenantManagement.Abstractions/Marain.TenantManagement.Abstractions.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.0.2" />
     <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="1.0.0" />
     <PackageReference Include="Corvus.Tenancy.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.TenantManagement.Cli/Marain.TenantManagement.Cli.csproj
+++ b/Solutions/Marain.TenantManagement.Cli/Marain.TenantManagement.Cli.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20158.1" />
     <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.TenantManagement.Specs/Marain.TenantManagement.Specs.csproj
+++ b/Solutions/Marain.TenantManagement.Specs/Marain.TenantManagement.Specs.csproj
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
We can't release this library without this update as the NuGet packaging step fails.