### PR TITLE
Force packaging to be enabled for the Services.Tenancy.Testing project.

### DIFF
--- a/Solutions/Marain.Services.Tenancy.Testing/Marain.Services.Tenancy.Testing.csproj
+++ b/Solutions/Marain.Services.Tenancy.Testing/Marain.Services.Tenancy.Testing.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -15,12 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Corvus.Testing.SpecFlow" Version="1.3.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes to the test SDK means the projects referencing it are not packable by default.

Once this change was made, packing failed due to issues related to the SpecFlow metapackage. However, this project should never have been referencing that package (it doesn't execute any tests itself, it just needs to be able to use SpecFlow and Corvus.Testing.SpecFlow references), so changed that reference as well,